### PR TITLE
BHA-95

### DIFF
--- a/bha/settings.py
+++ b/bha/settings.py
@@ -113,17 +113,30 @@ CORS_ORIGIN_ALLOW_ALL = True
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': os.environ['RDS_DB_NAME'],
-        'USER': os.environ['RDS_USERNAME'],
-        'PASSWORD': os.environ['RDS_PASSWORD'],
-        'HOST': os.environ['RDS_HOSTNAME'],
-        'PORT': os.environ['RDS_PORT'],
+if os.getenv('RDS_DB_NAME'):
+    # CI / Prod settings
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': os.environ['RDS_DB_NAME'],
+            'USER': os.environ['RDS_USERNAME'],
+            'PASSWORD': os.environ['RDS_PASSWORD'],
+            'HOST': os.environ['RDS_HOSTNAME'],
+            'PORT': os.environ['RDS_PORT'],
+        }
     }
-}
+else:
+    # Local (dev env) settings
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'mysql',
+            'USER': 'root',
+            'PASSWORD': 'password',
+            'HOST': 'localhost',
+            'PORT': '3306',
+        }
+    }
 
 
 # Password validation


### PR DESCRIPTION
Corrects how the switch to environment variables broke the connection to the database in dev. In particular, it does so by checking if environment variables are being used and, if so, using them; otherwise, it uses the default dev settings. The reason that it isn't a group of getOrElse calls is because if there is an environment that should be using environment variables and one of them isn't set, then it should raise an error as soon as possible, rather than attempting to run with the default values.