### PR TITLE
Bha 65

### DIFF
--- a/api/email.py
+++ b/api/email.py
@@ -49,6 +49,39 @@ def send_volunteer_welcome_email(name):
     msg.attach_alternative(html, "text/html")
     msg.send()
 
+################################ ADDED
+def update_to_assignment(update, name):
+    if update == 'added':
+        send_volunteer_added_assignment(name)
+    else:
+        send_volunteer_removed_assignment(name)
+
+
+def send_volunteer_added_assignment(name):
+    text_content = get_template('user_added_email_body.txt')
+    html_content = get_template('user_added_email_body.html')
+    c = get_context_volunteer_welcome(name)
+    text = text_content.render(c)
+    html = html_content.render(c)
+    from_email = testing_emails[0]
+    to_email = testing_emails[1]
+    msg = EmailMultiAlternatives(volunteer_added_to_assignment, text, from_email, [to_email])
+    msg.attach_alternative(html, "text/html")
+    msg.send()
+
+
+def send_volunteer_removed_assignment(name):
+    text_content = get_template('user_removed_email_body.txt')
+    html_content = get_template('user_removed_email_body.html')
+    c = get_context_volunteer_welcome(name)
+    text = text_content.render(c)
+    html = html_content.render(c)
+    from_email = testing_emails[0]
+    to_email = testing_emails[1]
+    msg = EmailMultiAlternatives(volunteer_removed_from_assignment, text, from_email, [to_email])
+    msg.attach_alternative(html, "text/html")
+    msg.send()
+################################ ADDED
 
 def send_staff_new_account_notice_email(name, volunteer_email, volunteer_phone):
     text_content = get_template('new_account_staff_email_body.txt')
@@ -269,6 +302,8 @@ carriers = {
 
 from_email, to = 'cs4500bha@gmail.com', 'bcox5021@gmail.com'
 
+testing_emails = ['hussein.abounassif93@gmail.com', 'hussein.abounassif93@gmail.com']
+
 bha_phone_number = "617-988-4032"
 
 bha_url = "https://www.bostonhousing.org/en/vip"
@@ -276,6 +311,10 @@ bha_url = "https://www.bostonhousing.org/en/vip"
 bha_email_address = "LanguageAccessTeam@bostonhousing.org"
 
 volunteer_welcome_subject = "[BHA] Thanks for Creating An Account With the Boston Housing Authority"
+
+volunteer_added_to_assignment = "[BHA] You Were Added to an Assignment With the Boston Housing Authority"
+
+volunteer_removed_from_assignment = "[BHA] You Were Removed from an Assignment With the Boston Housing Authority"
 
 staff_new_account_subject = "[BHA] A New Volunteer Has Created An Account"
 

--- a/api/email.py
+++ b/api/email.py
@@ -49,7 +49,7 @@ def send_volunteer_welcome_email(name):
     msg.attach_alternative(html, "text/html")
     msg.send()
 
-################################ ADDED
+
 def update_to_assignment(update, name):
     if update == 'added':
         send_volunteer_added_assignment(name)
@@ -63,9 +63,7 @@ def send_volunteer_added_assignment(name):
     c = get_context_volunteer_welcome(name)
     text = text_content.render(c)
     html = html_content.render(c)
-    from_email = testing_emails[0]
-    to_email = testing_emails[1]
-    msg = EmailMultiAlternatives(volunteer_added_to_assignment, text, from_email, [to_email])
+    msg = EmailMultiAlternatives(volunteer_added_to_assignment, text, from_email, [to])
     msg.attach_alternative(html, "text/html")
     msg.send()
 
@@ -76,12 +74,10 @@ def send_volunteer_removed_assignment(name):
     c = get_context_volunteer_welcome(name)
     text = text_content.render(c)
     html = html_content.render(c)
-    from_email = testing_emails[0]
-    to_email = testing_emails[1]
-    msg = EmailMultiAlternatives(volunteer_removed_from_assignment, text, from_email, [to_email])
+    msg = EmailMultiAlternatives(volunteer_removed_from_assignment, text, from_email, [to])
     msg.attach_alternative(html, "text/html")
     msg.send()
-################################ ADDED
+
 
 def send_staff_new_account_notice_email(name, volunteer_email, volunteer_phone):
     text_content = get_template('new_account_staff_email_body.txt')
@@ -302,7 +298,7 @@ carriers = {
 
 from_email, to = 'cs4500bha@gmail.com', 'bcox5021@gmail.com'
 
-testing_emails = ['hussein.abounassif93@gmail.com', 'hussein.abounassif93@gmail.com']
+testing_emails = ['hassuni123@gmail.com', 'hassuni123@gmail.com']
 
 bha_phone_number = "617-988-4032"
 

--- a/api/views.py
+++ b/api/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from rest_framework.decorators import detail_route, list_route
 from rest_framework import viewsets, views, filters #, status
 from .models import Volunteer, Assignment
-from .email import process_notification
+from .email import process_notification, update_to_assignment
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, AllowAny, IsAdminUser
 from .serializers import VolunteerSerializer, UserSerializer, AdminVolunteerSerializer, AdminAssignmentSerializer, AssignmentSerializer
@@ -119,6 +119,9 @@ class AssignmentViewSet(viewsets.ModelViewSet):
         assignment.volunteers.add(volunteer)
         assignment.save()
 
+        # Send confirmation email
+        update_to_assignment('added', volunteer.first_name)
+
         return Response({'success': 'volunteer added to assignment'})
 
     @detail_route(methods=['post'])
@@ -127,5 +130,8 @@ class AssignmentViewSet(viewsets.ModelViewSet):
         volunteer = get_object_or_404(Volunteer, id=request.data['volunteer_id'])
         assignment.volunteers.remove(volunteer)
         assignment.save()
+
+        # Send confirmation email
+        update_to_assignment('removed', volunteer.first_name)
 
         return Response({'success': 'volunteer removed from assignment'})

--- a/api/views.py
+++ b/api/views.py
@@ -120,7 +120,8 @@ class AssignmentViewSet(viewsets.ModelViewSet):
         assignment.save()
 
         # Send confirmation email
-        update_to_assignment('added', volunteer.first_name)
+        name = volunteer.first_name + " " + volunteer.last_name
+        update_to_assignment('added', name)
 
         return Response({'success': 'volunteer added to assignment'})
 
@@ -132,6 +133,7 @@ class AssignmentViewSet(viewsets.ModelViewSet):
         assignment.save()
 
         # Send confirmation email
-        update_to_assignment('removed', volunteer.first_name)
+        name = volunteer.first_name + " " + volunteer.last_name
+        update_to_assignment('removed', name)
 
         return Response({'success': 'volunteer removed from assignment'})

--- a/bha/settings.py
+++ b/bha/settings.py
@@ -97,13 +97,17 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 #EMAIL_HOST_USER = r'NORTHEAS10\bha'
 #EMAIL_HOST_PASSWORD = 'BHAmail3r!!'
 
-EMAIL_USE_TLS = True
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_HOST_USER = 'cs4500BHA@gmail.com'
-EMAIL_HOST_PASSWORD = 'mikeymike'
+# EMAIL_USE_TLS = True
+# EMAIL_HOST = 'smtp.gmail.com'
+# EMAIL_HOST_USER = 'cs4500BHA@gmail.com'
+# EMAIL_HOST_PASSWORD = 'mikeymike'
+# EMAIL_PORT = 587
+
+EMAIL_HOST = 'smtp.sendgrid.net'
+EMAIL_HOST_USER = 'hussein.abounassif93@gmail.com'
+EMAIL_HOST_PASSWORD = 'Thenotebook!23'
 EMAIL_PORT = 587
-
-
+EMAIL_USE_TLS = True
 
 CORS_ORIGIN_WHITELIST = (
     'local.bha.com',

--- a/bha/settings.py
+++ b/bha/settings.py
@@ -97,17 +97,12 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 #EMAIL_HOST_USER = r'NORTHEAS10\bha'
 #EMAIL_HOST_PASSWORD = 'BHAmail3r!!'
 
-# EMAIL_USE_TLS = True
-# EMAIL_HOST = 'smtp.gmail.com'
-# EMAIL_HOST_USER = 'cs4500BHA@gmail.com'
-# EMAIL_HOST_PASSWORD = 'mikeymike'
-# EMAIL_PORT = 587
-
-EMAIL_HOST = 'smtp.sendgrid.net'
-EMAIL_HOST_USER = 'hussein.abounassif93@gmail.com'
-EMAIL_HOST_PASSWORD = 'Thenotebook!23'
-EMAIL_PORT = 587
 EMAIL_USE_TLS = True
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_HOST_USER = 'cs4500BHA@gmail.com'
+EMAIL_HOST_PASSWORD = 'mikeymike'
+EMAIL_PORT = 587
+
 
 CORS_ORIGIN_WHITELIST = (
     'local.bha.com',

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Volunteer Interpreters Program</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="description" content="Boston Housing Authority Volunteer Management Application">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+    <base href="/">
+  </head>
+  <body ng-app="app" ng-strict-di ng-cloak>
+    <app>
+      Loading...
+    </app>
+  <script type="text/javascript" src="/vendor.bundle.js?a716664c755b61cdb3d8"></script><script type="text/javascript" src="/app.bundle.js?a716664c755b61cdb3d8"></script></body>
+</html>

--- a/scripts/refresh_app_startup.sh
+++ b/scripts/refresh_app_startup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sleep 15
+service nginx restart
+uwsgi --emperor /etc/uwsgi/vassals --master --daemonize /var/log/uwsgi.log
+

--- a/templates/user_added_email_body.html
+++ b/templates/user_added_email_body.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<p>Dear {{name}},</p>
+
+<p>
+  You were added to assignment.
+</p>
+</body>

--- a/templates/user_added_email_body.txt
+++ b/templates/user_added_email_body.txt
@@ -1,0 +1,3 @@
+Dear {{name}},
+
+You were added to a project.

--- a/templates/user_removed_email_body.html
+++ b/templates/user_removed_email_body.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<p>Dear {{name}},</p>
+
+<p>
+  You were removed from assignment.
+</p>
+</body>

--- a/templates/user_removed_email_body.txt
+++ b/templates/user_removed_email_body.txt
@@ -1,0 +1,3 @@
+Dear {{name}},
+
+You were removed from assignment.


### PR DESCRIPTION
- Inside settings.py, the email back end is commented out. I am not sure why, but maybe someone was testing and needed to check with the console. We might want to see why it was commented out as having the console backend won't actually send the emails. Below is what we currently have in the settings.py.

EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
#EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'